### PR TITLE
feat(#21): saved message structure

### DIFF
--- a/src/client/module/index.ts
+++ b/src/client/module/index.ts
@@ -1,0 +1,3 @@
+import { InboundResponse } from './inboundResponse.js'
+
+export { InboundResponse }

--- a/src/utils/normalizedClient.ts
+++ b/src/utils/normalizedClient.ts
@@ -1,6 +1,6 @@
 import { TcpSocketConnectOpts } from 'node:net'
 import type { ConnectionOptions as TLSOptions } from 'node:tls'
-import { InboundResponse } from '../client/module/inboundResponse.js'
+import { InboundResponse } from '../client/module'
 import { HL7FatalError } from './exception.js'
 import { assertNumber, validIPv4, validIPv6 } from './utils.js'
 
@@ -11,6 +11,26 @@ import { assertNumber, validIPv4, validIPv6 } from './utils.js'
  * @param res
  */
 export type OutboundHandler = (res: InboundResponse) => Promise<void> | void
+
+/**
+ * Saved Message Handler
+ * @remarks Used
+ * to send back to the application, the Hl7 message that need to be saved.
+ * Currently, the message is not able to send normally,
+ * or we are awaiting a previous acknowledgement that has yet to come.
+ *
+ * Errors that the client could experience are its own networking issues, or the remote side is having an issue,
+ * but regardless, this handler will be hit if specified for each connection.
+ *
+ * Instead of the messages being stored in Node.js memory, the object is returned
+ *
+ * @since 2.4.0
+ * @param message
+ * @return Return true if we successfully saved the message locally.
+ * If false (default) is returned, the system will keep looping until it knows the message has been successfully saved
+ * per the application specifications.
+ */
+export type SavedMessageHandler = (message: string) => Promise<boolean> | boolean
 
 const DEFAULT_CLIENT_OPTS = {
   encoding: 'utf-8',


### PR DESCRIPTION
- initial version that will save a message if there is no proper connection to the remote site
- client/app has to return 'true' in order for the system to know the message has been saved successfully.
- client/app can use what ever tool they want to save the stringify message
- when they notice a reconnect event, they should now take their messages (from disk, etc.) and re-send them.
- The remote side should still honor their original data structure, including when the message originally was generated

[skip ci]

## Search terms

<!-- Include keywords that might help others with the same problem find this issue -->

## Questioner

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

Other things:

- [ ] Write a unit test or update unit tests that cover your change in the code?
- [ ] Set the PR to merge into the develop branch?
- [ ] Clear documentation per the guidelines in the [README.md](../../README.md) as we are support medical applications?

