### PR TITLE
feat: client connection

### DIFF
--- a/__tests__/hl7.end2end.test.ts
+++ b/__tests__/hl7.end2end.test.ts
@@ -13,6 +13,8 @@ describe('node hl7 end to end - client', () => {
 
     test('...simple connect', async () => {
 
+      await tcpPortUsed.check(3000, '0.0.0.0')
+
       let dfd = createDeferred<void>()
       let dfdConnectionChecks = createDeferred<void>()
 
@@ -73,8 +75,7 @@ describe('node hl7 end to end - client', () => {
       client.closeAll()
 
       await dfdConnectionChecks.promise;
-      expect(outbound._connectionTimer).toBeDefined();
-      expect((outbound._connectionTimer as any)._destroyed).toBeTruthy();
+      expect(outbound._connectionTimer).toBeUndefined();
       expect((outbound as any)._readyState).toEqual(ReadyState.CLOSED);
       expect(client._connections.length).toEqual(0);
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lib/"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.15.0"
   },
   "scripts": {
     "clean": "rm -rf coverage docs lib temp",
@@ -75,25 +75,25 @@
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@the-rabbit-hole/semantic-release-config": "^1.5.0",
-    "@types/node": "^20.14.9",
+    "@types/node": "^22.8.5",
     "@types/tcp-port-used": "^1.0.4",
-    "@typescript-eslint/parser": "^7.14.1",
-    "@vitest/coverage-v8": "^1.6.0",
-    "@vitest/ui": "^1.6.0",
-    "node-hl7-server": "^2.4.1",
-    "npm-check-updates": "^16.14.20",
+    "@typescript-eslint/parser": "^8.12.2",
+    "@vitest/coverage-v8": "^2.1.4",
+    "@vitest/ui": "^2.1.4",
+    "node-hl7-server": "^3.0.0",
+    "npm-check-updates": "^17.1.9",
     "npm-package-json-lint": "^8.0.0",
     "portfinder": "^1.0.32",
     "pre-commit": "^1.2.2",
-    "semantic-release": "^24.0.0",
+    "semantic-release": "^24.2.0",
     "snazzy": "^9.0.0",
     "tcp-port-used": "^1.0.2",
     "ts-node": "^10.9.2",
     "ts-standard": "^12.0.2",
-    "tsd": "^0.31.1",
-    "typedoc": "^0.26.3",
-    "typescript": "5.5.4",
-    "vitest": "^1.6.0"
+    "tsd": "^0.31.2",
+    "typedoc": "^0.26.10",
+    "typescript": "5.6.3",
+    "vitest": "^2.1.4"
   },
   "precommit": [
     "lint:fix",

--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -339,7 +339,7 @@ export class Connection extends EventEmitter implements IConnection {
     socket.on('close', () => {
       if (this._readyState === ReadyState.CLOSING) {
         this._readyState = ReadyState.CLOSED
-      } else if (!(this._readyState === ReadyState.CLOSED && this._connectionTimer != null && (this._connectionTimer as unknown as { _destroyed: boolean })._destroyed)) {
+      } else if ((!(this._readyState === ReadyState.CLOSED && this._connectionTimer != null && (this._connectionTimer as unknown as { _destroyed: boolean })._destroyed)) && this._main._opt.connectionTimeout > 0) {
         connectionError = (connectionError != null) ? connectionError : new HL7FatalError('Socket closed unexpectedly by server.')
         if (this._readyState === ReadyState.OPEN) {
           this._onConnect = createDeferred(true)

--- a/src/utils/normalizedClient.ts
+++ b/src/utils/normalizedClient.ts
@@ -14,7 +14,7 @@ export type OutboundHandler = (res: InboundResponse) => Promise<void> | void
 
 const DEFAULT_CLIENT_OPTS = {
   encoding: 'utf-8',
-  connectionTimeout: 10000,
+  connectionTimeout: 0,
   maxAttempts: 10,
   maxConnectionAttempts: 10,
   maxTimeout: 10,
@@ -32,10 +32,10 @@ const DEFAULT_LISTEN_CLIENT_OPTS = {
 export interface ClientOptions {
   /**
    * How long a connection attempt checked before ending the socket and attempting again.
-   * Min. is 1000 (1 second) and Max. is 60000 (60 seconds.)
-   * Note: Less than 10 seconds could cause some serious issues.
+   * If this is set to zero, the client will stay connected.
+   * Min. is 0 (Stay Connected), and Max. is 60000 (60 seconds.)
    * Use with caution.
-   * @default 10000
+   * @default 0
    */
   connectionTimeout?: number
   /** Host - You can do a FQDN or the IPv(4|6) address. */
@@ -160,7 +160,7 @@ export function normalizeClientOptions (raw?: ClientOptions): ValidatedClientOpt
     props.tls = {}
   }
 
-  assertNumber(props, 'connectionTimeout', 1000, 60000)
+  assertNumber(props, 'connectionTimeout', 0, 60000)
   assertNumber(props, 'maxTimeout', 1, 50)
 
   return props


### PR DESCRIPTION
* default 0 second idle time keeps the connection open
* disables connection timeout logic if set to 0 (stay connected)
* updated unit test to reflect that

BREAKING CHANGE: Default now set to be always connected. Must set connectionTimeout, if you want your client to disconnect after a certain time. The max is still 60 seconds.

Closes #169

## Search terms

connection timeout

## Questioner

Please check the type of change your PR introduces:

- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

Other things:

- [X] Write a unit test or update unit tests that cover your change in the code?
- [X] Set the PR to merge into the develop branch?
- [X] Clear documentation per the guidelines in the [README.md](../../README.md) as we are support medical applications?

