### PR TITLE
fix: segment detection regex matches "MSH|" mid-field; CR substitution uses literal string instead of character

### DIFF
--- a/__tests__/hl7.sanity.test.ts
+++ b/__tests__/hl7.sanity.test.ts
@@ -265,6 +265,9 @@ describe("node hl7 client - sanity tests", () => {
       "MSH|^~\\&|device||Host||20240101000000+0000||OUL^R22^OUL_R22|2|P|2.5.1|||NE|AL||UNICODE UTF-8|||LAB-01^IHE\r";
     const hl7_timezone: string =
       "MSH|^~\\\\&|device||Host||19981004010159+0100||OUL^R22^OUL_R22|2|P|2.5.1|||NE|AL||UNICODE UTF-8|||LAB-01^IHE\\r";
+    // EVN segment contains "MSH|fake" in fields 3-4 — raw text has "MSH|" mid-line
+    const hl7_msh_mid_line: string =
+      "MSH|^~\\&|||||20081231||ADT^A01^ADT_A01|12345||2.7\rEVN||20081231|MSH|fake";
 
     test("... timezone offset", async () => {
       const message = new Message({ text: hl7_timezone });
@@ -363,6 +366,15 @@ describe("node hl7 client - sanity tests", () => {
         });
         expect(count).toBe(1);
       });
+    });
+
+    test("...MSH mid-line inside another segment is not treated as a segment start", async () => {
+      // hl7_msh_mid_line has "MSH|" appearing inside the EVN segment (EVN.3=MSH, EVN.4=fake)
+      // The old regex matched "MSH|" anywhere and would falsely detect a second MSH segment.
+      // The new ^-multiline regex only matches at start of line, so no false split occurs.
+      const message = new Message({ text: hl7_msh_mid_line });
+      expect(message.get("EVN.3").toString()).toBe("MSH");
+      expect(message.get("EVN.4").toString()).toBe("fake");
     });
   });
 });

--- a/src/utils/normalizedBuilder.ts
+++ b/src/utils/normalizedBuilder.ts
@@ -179,7 +179,7 @@ export function normalizedClientFileBuilderOptions(
   }
 
   const regex = /\n/gm;
-  const subst = "\\r";
+  const subst = "\r";
   if (
     typeof props.fullFilePath !== "undefined" &&
     typeof props.fileBuffer === "undefined"

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -239,20 +239,10 @@ const getSegIndexes = (
   list: string[] = [],
 ): string[] => {
   for (let i = 0; i < names.length; i++) {
-    const regex = new RegExp(`(\\n|\\r|)(${names[i]})\\|`, "g");
+    const regex = new RegExp(`^(${names[i]})\\|`, "gm");
     let m;
     while ((m = regex.exec(data)) != null) {
-      const s = m[0];
-      if (s.includes("\r\n")) {
-        m.index = m.index + 2;
-      } else if (s.includes("\n")) {
-        m.index++;
-      } else if (s.includes("\r")) {
-        m.index++;
-      }
-      if (m.index !== null) {
-        list.push(m.index.toString());
-      }
+      list.push(m.index.toString());
     }
   }
   return list;


### PR DESCRIPTION
## Search terms

Please, check https://github.com/Bugs5382/node-hl7-client/issues/208

## Questioner

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

Other things:

- [x] Write a unit test or update unit tests that cover your change in the code?
- [x] Set the PR to merge into the develop branch?
- [ ] Clear documentation per the guidelines in the [README.md](../../README.md) as we are support medical applications?

